### PR TITLE
Add setReverb method

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ dependencies {
                                   // synthesizer (between 0 and 100).
                                   // Returns true on success, false on
                                   // failure.
+    boolean setReverb(int preset) // Set Reverb effect preset for EAS
+                                  // synthesizer (value from
+                                  // ReverbConstants). Returns true
+                                  // on success, false on failure.
 
     boolean shutdown() // Shut down the synthesizer. Returns true on
                        // success, false on failure.
@@ -113,6 +117,16 @@ dependencies {
     jboolean midi_setVolume(jint volume)
                                   // Set master volume for EAS
                                   // synthesizer (between 0 and 100).
+                                  // Returns true on success, false on
+                                  // failure.
+    jboolean midi_setReverb(jint preset)
+                                  // Set Reverb effect preset for EAS
+                                  // synthesizer. Preset could be:
+                                  //   -1: turn reverb off
+                                  //    0: large hall
+                                  //    1: hall
+                                  //    2: chamber
+                                  //    3: room.
                                   // Returns true on success, false on
                                   // failure.
     jboolean midi_shutdown() // Shut down the synthesizer. Returns true on

--- a/app/src/main/java/org/billthefarmer/miditest/MainActivity.java
+++ b/app/src/main/java/org/billthefarmer/miditest/MainActivity.java
@@ -25,6 +25,7 @@ package org.billthefarmer.miditest;
 import android.app.Activity;
 import android.media.MediaPlayer;
 import android.os.Bundle;
+import android.widget.CompoundButton;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.TextView;
@@ -32,6 +33,7 @@ import android.widget.TextView;
 import org.billthefarmer.mididriver.MidiDriver;
 import org.billthefarmer.mididriver.MidiConstants;
 import org.billthefarmer.mididriver.GeneralMidiConstants;
+import org.billthefarmer.mididriver.ReverbConstants;
 
 import java.util.Locale;
 
@@ -70,6 +72,18 @@ public class MainActivity extends Activity
         v = findViewById(R.id.nants);
         if (v != null)
             v.setOnClickListener(this);
+
+        v = findViewById(R.id.reverb);
+        if (v != null)
+            ((CompoundButton)v).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                        if (isChecked) {
+                            midi.setReverb(ReverbConstants.CHAMBER);
+                        } else {
+                            midi.setReverb(ReverbConstants.OFF);
+                        }
+                    }
+                });
 
         text = findViewById(R.id.status);
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,6 +33,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/g" />
+
+        <ToggleButton
+            android:id="@+id/reverb"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:textOn="@string/reverbon"
+            android:textOff="@string/reverboff" />
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,10 +4,11 @@
     <string name="app_name">Midi</string>
     <string name="intro">
         To test the midi driver, touch the <b>C chord</b> or <b>G
-        chord</b> buttons below. The <b>Ants</b> and <b><u>Ants</u></b>
-        buttons play and stop playing a short midi tune file from the
-        Sonivox sources. The chord buttons use the driver, the tune
-        buttons use the standard Android midi file player. They should all
+        chord</b> buttons below. Press <b>Reverb</b> to toggle the effect.
+        The <b>Ants</b> and <b><u>Ants</u></b> buttons play and stop
+        playing a short midi tune file from the Sonivox sources.
+        The chord buttons use the driver, the tune buttons use the
+        standard Android midi file player. They should all
         work simultaneously.
     </string>
 
@@ -15,6 +16,8 @@
     <string name="g">G chord</string>
     <string name="ants">Ants</string>
     <string name="nants"><u>Ants</u></string>
+    <string name="reverbon">Reverb</string>
+    <string name="reverboff">Reverb</string>
 
     <string name="format" formatted="false">
         Sonivox synthesizer config:\n

--- a/library/src/main/java/org/billthefarmer/mididriver/MidiDriver.java
+++ b/library/src/main/java/org/billthefarmer/mididriver/MidiDriver.java
@@ -124,6 +124,13 @@ public class MidiDriver
     public  native boolean setVolume(int volume);
 
     /**
+     * Set EAS module parameter
+     * @param preset reverb preset to use (value from ReverbConstants)
+     * @return true for success
+     */
+    public native boolean setReverb(int preset);
+
+    /**
      * Shut down native code
      *
      * @return true for success

--- a/library/src/main/java/org/billthefarmer/mididriver/ReverbConstants.java
+++ b/library/src/main/java/org/billthefarmer/mididriver/ReverbConstants.java
@@ -16,39 +16,20 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-//  Bill Farmer	 william j farmer [at] yahoo [dot] co [dot] uk.
+//  Joseph Hindin hindin [at] jhindin [dot] com
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef MIDI_H
-#define MIDI_H
+package org.billthefarmer.mididriver;
 
-#include <jni.h>
-#include "eas.h"
-
-/* for C++ linkage */
-#ifdef __cplusplus
-extern "C"
+/**
+ * Reverb presets constants
+ */
+public class ReverbConstants
 {
-#endif
-
-// init mididriver
-jboolean midi_init();
-
-// midi write
-jboolean midi_write(EAS_U8 *bytes, jint length);
-
-// set EAS master volume
-jboolean midi_setVolume(jint volume);
-
-// set EAS reverb preset
-jboolean midi_setReverb(jint preset);
-
-// shutdown EAS midi
-jboolean midi_shutdown();
-
-#ifdef __cplusplus
-} /* end extern "C" */
-#endif
-
-#endif /* MIDI_H */
+    public static final byte OFF                            = -1;
+    public static final byte LARGE_HALL                     = 0;
+    public static final byte HALL                           = 1;
+    public static final byte CHAMBER                        = 2;
+    public static final byte ROOM                           = 3;
+}

--- a/library/src/main/jni/midi.cpp
+++ b/library/src/main/jni/midi.cpp
@@ -464,6 +464,47 @@ Java_org_billthefarmer_mididriver_MidiDriver_setVolume(JNIEnv *env,
     return midi_setVolume(volume);
 }
 
+// Set EAS reverb
+jboolean midi_setReverb(jint preset)
+{
+    EAS_RESULT result;
+
+    if (preset >= 0) {
+        result = EAS_SetParameter(pEASData, EAS_MODULE_REVERB, EAS_PARAM_REVERB_PRESET, preset);
+        if (result != EAS_SUCCESS)
+        {
+            LOG_E(LOG_TAG, "Set EAS reverb preset failed: %ld", result);
+            return JNI_FALSE;
+        }
+
+        result = EAS_SetParameter(pEASData, EAS_MODULE_REVERB, EAS_PARAM_REVERB_BYPASS, EAS_FALSE);
+        if (result != EAS_SUCCESS)
+        {
+            LOG_E(LOG_TAG, "Enable EAS reverb failed: %ld", result);
+            return JNI_FALSE;
+        }
+    }
+    else
+    {
+        result = EAS_SetParameter(pEASData, EAS_MODULE_REVERB, EAS_PARAM_REVERB_BYPASS, EAS_TRUE);
+        if (result != EAS_SUCCESS)
+        {
+            LOG_E(LOG_TAG, "Disable EAS reverb failed: %ld", result);
+            return JNI_FALSE;
+        }
+    }
+
+    return JNI_TRUE;
+}
+
+jboolean
+Java_org_billthefarmer_mididriver_MidiDriver_setReverb(JNIEnv *env,
+                                                          jobject obj,
+                                                          jint preset)
+{
+    return midi_setReverb(preset);
+}
+
 // shutdown EAS midi
 jboolean midi_shutdown() {
     EAS_RESULT result;

--- a/library/src/main/jni/org_billthefarmer_mididriver_MidiDriver.h
+++ b/library/src/main/jni/org_billthefarmer_mididriver_MidiDriver.h
@@ -42,6 +42,15 @@ JNIEXPORT jboolean JNICALL Java_org_billthefarmer_mididriver_MidiDriver_setVolum
 
 /*
  * Class:     org_billthefarmer_mididriver_MidiDriver
+ * Method:    setReverb
+ * Signature: (I)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_billthefarmer_mididriver_MidiDriver_setReverb
+(JNIEnv *, jobject, jint);
+
+
+/*
+ * Class:     org_billthefarmer_mididriver_MidiDriver
  * Method:    shutdown
  * Signature: ()Z
  */


### PR DESCRIPTION
Hi,
Thanks for developing this awesome library.

This PR adds method to control the reverb effect preset:
```java
// Enable effect, and set preset
midi.setReverb(ReverbConstants.LARGE_HALL)
// Disable effect
midi.setReverb(ReverbConstants.OFF)
```

* Added Java method: setReverb
* Added C/C++ method: midi_setReverb
* Added *Reverb* toggle button to the Midi demo app

Related issue: #5


![image](https://user-images.githubusercontent.com/1408660/105513748-bd686880-5ce3-11eb-923a-6f526eff5fa0.png)
