### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+# Build on push and PR events
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Show checksums
+        run: |
+          sha256sum library/build/outputs/aar/library-release.aar
+          sha256sum app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Upload library
+        uses: actions/upload-artifact@v2
+        with:
+          name: library-release.aar
+          path: library/build/outputs/aar/library-release.aar
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+# Release on new tags
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: List files
+        run: find
+
+      - name: Get the tag version
+        id: version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+
+      - name: Show checksums
+        run: |
+          sha256sum library/build/outputs/aar/library-release.aar
+          sha256sum app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "${{ steps.version.outputs.VERSION }}"
+          release_name: "Version ${{ steps.version.outputs.VERSION }}"
+
+      - name: Upload library
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: library/build/outputs/aar/library-release.aar
+          asset_name: "MidiDriver-${{ steps.version.outputs.VERSION }}.aar"
+          asset_content_type: application/java-archive
+
+      - name: Upload APK
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: app/build/outputs/apk/debug/app-debug.apk
+          asset_name: "MidiDriverTest-${{ steps.version.outputs.VERSION }}.apk"
+          asset_content_type: application/vnd.android.package-archive


### PR DESCRIPTION
Hi

Due to recent changes in Travic CI plans: https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing , its use becomes problematic.

I was using GitHub Actions to build version with setReverb method. Hopefully some parts of this PR might be helpful in case a switch is planned. 

Implemented building scenario:
  * On commit push or Pull request: run build and save results (AAR + APK) as artifacts. GitHub will store artifacts for 90 days.
  * On tag push starting with "v": run build, create new release and attach results to it. Description could be added to release manually.