### PR TITLE
Update Google Oboe to v1.9.3 to support 16KB memory page sizes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "org.billthefarmer.miditest"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionName "1.27"
         versionCode 127

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,7 +21,7 @@ android {
     ndkVersion "28.1.13356709"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 127
         versionName "1.27"
@@ -62,5 +62,5 @@ afterEvaluate {
 }
 
 dependencies {
-    implementation 'com.google.oboe:oboe:1.6.1'
+    implementation 'com.google.oboe:oboe:1.9.3'
 }


### PR DESCRIPTION
### Changes
- Updated Google Oboe library to v1.9.3 to support 16KB memory page sizes (fixes #52).
- Updated `minSdk` from 16 to 21 for compatibility with Oboe v1.9.3. (If compatibility with API 16 is still required another solution may be needed.)

### Testing
- I've built the library and verified MIDI playback functionality inside the demo app and my own dependent app.
- Also verified the `.aar` file does not contain any non-16KB aligned files.
- May require more testing to ensure full functionality of the library is maintained.