### PR TITLE
Implement memory DLS loader

### DIFF
--- a/library/src/main/java/org/billthefarmer/mididriver/MidiDriver.java
+++ b/library/src/main/java/org/billthefarmer/mididriver/MidiDriver.java
@@ -163,6 +163,13 @@ public class MidiDriver
      */
     private native boolean shutdown();
 
+    /**
+     * Load DLS soundbank from memory
+     *
+     * @param byte array of DLS file data
+     */
+    public native boolean loadDLS(byte a[]);
+
     // Load midi library
     static
     {

--- a/library/src/main/jni/eas_midi.c
+++ b/library/src/main/jni/eas_midi.c
@@ -49,6 +49,93 @@
 #include "eas_mdls.h"
 #endif
 
+static EAS_RESULT MIDIStream_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 *pState);
+static EAS_RESULT MIDIStream_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue);
+
+/*---------------------------------------------------------------------------- 
+  * 
+  * EAS_MIDIStream_Parser 
+  * 
+  * This structure contains the functional interface for the MIDI Stream parser 
+  *---------------------------------------------------------------------------- 
+ */ 
+const static S_FILE_PARSER_INTERFACE EAS_MIDIStream_Parser = 
+{ 
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    MIDIStream_State,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    MIDIStream_GetData,
+    NULL 
+};
+
+/*----------------------------------------------------------------------------
+ * MIDIStream_State()
+ *----------------------------------------------------------------------------
+ * Purpose:
+ * Returns the current state of the stream
+ *
+ * Inputs:
+ * pEASData         - pointer to overall EAS data structure
+ * handle           - pointer to file handle
+ * pState           - pointer to variable to store state
+ *
+ * Outputs:
+ *
+ *
+ * Side Effects:
+ *
+ *----------------------------------------------------------------------------
+*/
+/*lint -esym(715, pEASData) common decoder interface - pEASData not used */
+static EAS_RESULT MIDIStream_State (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 *pState)
+{
+    *pState = EAS_STATE_READY;
+    return EAS_SUCCESS;
+}
+
+/*----------------------------------------------------------------------------
+ * MIDIStream_GetData()
+ *----------------------------------------------------------------------------
+ * Purpose:
+ * Get specified data
+ *
+ * Inputs:
+ * pEASData         - pointer to overall EAS data structure
+ * handle           - pointer to file handle
+ *
+ * Outputs:
+ *
+ *
+ * Side Effects:
+ *
+ *----------------------------------------------------------------------------
+*/
+/*lint -esym(715, pEASData) common decoder interface - pEASData not used */
+static EAS_RESULT MIDIStream_GetData (S_EAS_DATA *pEASData, EAS_VOID_PTR pInstData, EAS_I32 param, EAS_I32 *pValue)
+{
+    S_INTERACTIVE_MIDI *pData;
+
+    pData = (S_INTERACTIVE_MIDI*) pInstData;
+    switch (param)
+    {
+        case PARSER_DATA_SYNTH_HANDLE:
+            *pValue = (EAS_I32) pData->pSynth;
+            break;
+
+        default:
+            return EAS_ERROR_INVALID_PARAMETER;
+    }
+    return EAS_SUCCESS;
+}
+
 /*----------------------------------------------------------------------------
  * EAS_AllocateStream()
  *----------------------------------------------------------------------------
@@ -181,7 +268,7 @@ EAS_PUBLIC EAS_RESULT EAS_OpenMIDIStream (EAS_DATA_HANDLE pEASData, EAS_HANDLE *
 
     /* zero the memory to insure complete initialization */
     EAS_HWMemSet(pMIDIStream, 0, sizeof(S_INTERACTIVE_MIDI));
-    EAS_InitStream(&pEASData->streams[streamNum], NULL, pMIDIStream);
+    EAS_InitStream(&pEASData->streams[streamNum], (EAS_VOID_PTR) &EAS_MIDIStream_Parser, pMIDIStream);
 
     /* instantiate a new synthesizer */
     if (streamHandle == NULL)

--- a/library/src/main/jni/host_src/eas.h
+++ b/library/src/main/jni/host_src/eas.h
@@ -608,6 +608,28 @@ EAS_PUBLIC EAS_RESULT EAS_MetricsReport (EAS_DATA_HANDLE pEASData);
 EAS_PUBLIC EAS_RESULT EAS_MetricsReset (EAS_DATA_HANDLE pEASData);
 #endif
 
+#ifdef DLS_SYNTHESIZER
+/*----------------------------------------------------------------------------
+ * EAS_LoadDLSCollection()
+ *----------------------------------------------------------------------------
+ * Purpose:
+ * Downloads a DLS collection
+ *
+ * Inputs:
+ * pEASData             - instance data handle
+ * streamHandle         - file or stream handle
+ * locator              - file locator
+ *
+ * Outputs:
+ *
+ *
+ * Side Effects:
+ *
+ *----------------------------------------------------------------------------
+*/
+EAS_PUBLIC EAS_RESULT EAS_LoadDLSCollection (EAS_DATA_HANDLE pEASData, EAS_HANDLE streamHandle, EAS_FILE_LOCATOR locator);
+#endif
+
 /*----------------------------------------------------------------------------
  * EAS_SearchFile
  *----------------------------------------------------------------------------

--- a/library/src/main/jni/lib_src/eas_mdls.c
+++ b/library/src/main/jni/lib_src/eas_mdls.c
@@ -1615,6 +1615,14 @@ static EAS_RESULT Parse_insh (SDLS_SYNTHESIZER_DATA *pDLSData, EAS_I32 pos, EAS_
         { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS bank number is out of range: %08lx\n", bank); */ }
         bank &= 0xff7f;
     }
+
+    bank &= 0x7f7f;
+    if (bank & 0x80000000u || ((bank >> 8) & 0x7f) == DEFAULT_RHYTHM_BANK_MSB)
+    {
+        // drum instrument
+        bank |= 0x10000;
+    }
+
     if (program > 127)
     {
         { /* dpp: EAS_ReportEx(_EAS_SEVERITY_WARNING, "DLS program number is out of range: %08lx\n", program); */ }

--- a/library/src/main/jni/lib_src/eas_public.c
+++ b/library/src/main/jni/lib_src/eas_public.c
@@ -1629,6 +1629,60 @@ EAS_PUBLIC EAS_RESULT EAS_MetricsReset (EAS_DATA_HANDLE pEASData)
 }
 #endif
 
+#ifdef DLS_SYNTHESIZER
+/*----------------------------------------------------------------------------
+ * EAS_LoadDLSCollection()
+ *----------------------------------------------------------------------------
+ * Purpose:
+ * Sets the location of the sound library.
+ *
+ * Inputs:
+ * pEASData             - instance data handle
+ * pSoundLib            - pointer to sound library
+ *
+ * Outputs:
+ *
+ *
+ * Side Effects:
+ *
+ *----------------------------------------------------------------------------
+*/
+EAS_PUBLIC EAS_RESULT EAS_LoadDLSCollection (EAS_DATA_HANDLE pEASData, EAS_HANDLE pStream, EAS_FILE_LOCATOR locator)
+{
+    EAS_FILE_HANDLE fileHandle;
+    EAS_RESULT result;
+    EAS_DLSLIB_HANDLE pDLS;
+
+    if (pStream != NULL)
+    {
+        if (!EAS_StreamReady(pEASData, pStream))
+            return EAS_ERROR_NOT_VALID_IN_THIS_STATE;
+    }
+
+    /* open the file */
+    if ((result = EAS_HWOpenFile(pEASData->hwInstData, locator, &fileHandle, EAS_FILE_READ)) != EAS_SUCCESS)
+        return result;
+
+    /* parse the file */
+    result = DLSParser(pEASData->hwInstData, fileHandle, 0, &pDLS);
+    EAS_HWCloseFile(pEASData->hwInstData, fileHandle);
+
+    if (result == EAS_SUCCESS)
+    {
+
+        /* if a stream pStream is specified, point it to the DLS collection */
+        if (pStream)
+            result = EAS_IntSetStrmParam(pEASData, pStream, PARSER_DATA_DLS_COLLECTION, (EAS_I32) pDLS);
+
+        /* global DLS load */
+        else
+            result = VMSetGlobalDLSLib(pEASData, pDLS);
+    }
+
+    return result;
+}
+#endif
+
 #ifdef FILE_HEADER_SEARCH
 /*----------------------------------------------------------------------------
  * EAS_SearchFile

--- a/library/src/main/jni/org_billthefarmer_mididriver_MidiDriver.h
+++ b/library/src/main/jni/org_billthefarmer_mididriver_MidiDriver.h
@@ -57,6 +57,14 @@ JNIEXPORT jboolean JNICALL Java_org_billthefarmer_mididriver_MidiDriver_setRever
 JNIEXPORT jboolean JNICALL Java_org_billthefarmer_mididriver_MidiDriver_shutdown
         (JNIEnv *, jobject);
 
+/*
+ * Class:     org_billthefarmer_mididriver_MidiDriver
+ * Method:    loadDLS
+ * Signature: ([B)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_billthefarmer_mididriver_MidiDriver_loadDLS
+        (JNIEnv *, jobject, jbyteArray);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Changes I made

1. Implemented loading DLS soundbank from memory
2. Improved DLS Program lookup logic
3. When DLS soundbank is loaded, the original EAS soundbank will be disabled

I have compiled and tested the code before creating this pull request

If you think some of the names have better alternatives, feel free to change them